### PR TITLE
Return error when has required filters and an empty list of params

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.10.3
+elixir 1.13.1-otp-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2022-08-22
+
+### Fix
+
+- required validation for an empty list of params
+
 ## [0.2.2] - 2022-01-05
 
 ## [0.2.1] - 2021-12-01
@@ -47,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add lib documentation
 
-[unreleased]: https://github.com/Finbits/strong_params/compare/v0.2.2...main
+[unreleased]: https://github.com/Finbits/strong_params/compare/v0.2.3...main
+[0.2.3]: https://github.com/Finbits/strong_params/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Finbits/strong_params/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Finbits/strong_params/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Finbits/strong_params/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:strong_params, "~> 0.2.2"}
+    {:strong_params, "~> 0.2.3"}
   ]
 end
 ```

--- a/lib/strong_params/filter.ex
+++ b/lib/strong_params/filter.ex
@@ -90,6 +90,12 @@ defmodule StrongParams.Filter do
     respond_reduce_with(partial_result, params)
   end
 
+  defp reduce_function(filters, {%{}, [] = params}, :required) when is_list(filters) do
+    filters
+    |> Enum.reduce(%{}, &reduce_empty_required_list/2)
+    |> respond_reduce_with(params)
+  end
+
   defp reduce_function(filters, {%{}, params}, mode)
        when is_list(filters) and is_list(params) do
     params
@@ -109,6 +115,14 @@ defmodule StrongParams.Filter do
       %Error{} = error -> {:halt, error}
       result -> {:cont, [result | list]}
     end
+  end
+
+  defp reduce_empty_required_list(key, acc) when is_atom(key) do
+    add_to_result(acc, key, :key_not_found, :required)
+  end
+
+  defp reduce_empty_required_list({key, _value}, acc) when is_atom(key) do
+    reduce_empty_required_list(key, acc)
   end
 
   defp add_to_result(%Error{errors: errors} = error, key, :key_not_found, :required),

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule StrongParams.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @description "Filter request parameters in a Phoenix app"
   @links %{"GitHub" => "https://github.com/Finbits/strong_params"}
 

--- a/test/strong_params/filter_test.exs
+++ b/test/strong_params/filter_test.exs
@@ -417,5 +417,21 @@ defmodule StrongParams.FilterTest do
                errors: %{attachments: %{info: %{size: "is required"}}}
              }
     end
+
+    test "returns error when has required filters and it was given an empty list as params" do
+      params = %{"attachments" => []}
+
+      filters = [
+        required: [attachments: [[:info, address: [:street, :city]]]],
+        permitted: [attachments: [[:name]]]
+      ]
+
+      result = Filter.apply(params, filters)
+
+      assert result == %StrongParams.Error{
+               errors: %{attachments: %{address: "is required", info: "is required"}},
+               type: "required"
+             }
+    end
   end
 end


### PR DESCRIPTION
## Motivation

We are not returning an error when you have required attributes of a list item and that list was empty.

## Proposed solution

Add errors when has a list of filters and the parameters is an empty list.
