### PR TITLE
Rename error for forbidden params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-05-16
+
+### Changed
+
+- Rename forbidden parameters error
+
 ## [0.3.0] - 2024-05-10
 
 ### Added
@@ -59,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add lib documentation
 
-[unreleased]: https://github.com/Finbits/strong_params/compare/v0.3.0...main
+[unreleased]: https://github.com/Finbits/strong_params/compare/v0.4.0...main
+[0.4.0]: https://github.com/Finbits/strong_params/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Finbits/strong_params/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Finbits/strong_params/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Finbits/strong_params/compare/v0.2.1...v0.2.2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:strong_params, "~> 0.3.0"}
+    {:strong_params, "~> 0.4.0"}
   ]
 end
 ```

--- a/lib/strong_params/filter.ex
+++ b/lib/strong_params/filter.ex
@@ -6,7 +6,7 @@ defmodule StrongParams.Filter do
 
   defguardp is_cast_type(type) when is_atom(type) or is_tuple(type)
 
-  @forbidden_msg "is not a valid parameter"
+  @forbidden_msg "is not a permitted parameter"
   @invalid_msg "is invalid"
   @required_msg "is required"
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule StrongParams.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @description "Filter request parameters in a Phoenix app"
   @links %{"GitHub" => "https://github.com/Finbits/strong_params"}
 

--- a/test/strong_params/filter_test.exs
+++ b/test/strong_params/filter_test.exs
@@ -462,7 +462,10 @@ defmodule StrongParams.FilterTest do
 
       result = Filter.apply(params, required: [:name, :description], forbidden_params_err: true)
 
-      assert result == %Error{type: "forbidden", errors: %{"role" => "is not a valid parameter"}}
+      assert result == %Error{
+               type: "forbidden",
+               errors: %{"role" => "is not a permitted parameter"}
+             }
     end
 
     test "return error for forbidden params when opt is given (multiple errors)" do
@@ -477,8 +480,8 @@ defmodule StrongParams.FilterTest do
       assert result == %Error{
                type: "forbidden",
                errors: %{
-                 "role" => "is not a valid parameter",
-                 "description" => "is not a valid parameter"
+                 "role" => "is not a permitted parameter",
+                 "description" => "is not a permitted parameter"
                }
              }
     end
@@ -511,7 +514,7 @@ defmodule StrongParams.FilterTest do
 
       assert result == %Error{
                type: "forbidden",
-               errors: %{"attachments" => %{"info" => %{"id" => "is not a valid parameter"}}}
+               errors: %{"attachments" => %{"info" => %{"id" => "is not a permitted parameter"}}}
              }
     end
 
@@ -545,11 +548,11 @@ defmodule StrongParams.FilterTest do
                errors: %{
                  "attachments" => %{
                    "info" => %{
-                     "id" => "is not a valid parameter",
-                     "type" => "is not a valid parameter"
+                     "id" => "is not a permitted parameter",
+                     "type" => "is not a permitted parameter"
                    }
                  },
-                 "name" => "is not a valid parameter"
+                 "name" => "is not a permitted parameter"
                }
              }
     end
@@ -583,7 +586,7 @@ defmodule StrongParams.FilterTest do
                type: "forbidden",
                errors: %{
                  "attachments" => %{
-                   "information" => %{"tags" => %{"deleted" => "is not a valid parameter"}}
+                   "information" => %{"tags" => %{"deleted" => "is not a permitted parameter"}}
                  }
                }
              }
@@ -619,13 +622,13 @@ defmodule StrongParams.FilterTest do
       assert result == %Error{
                type: "forbidden",
                errors: %{
-                 "name" => "is not a valid parameter",
+                 "name" => "is not a permitted parameter",
                  "attachments" => %{
-                   "extension" => "is not a valid parameter",
+                   "extension" => "is not a permitted parameter",
                    "information" => %{
                      "tags" => %{
-                       "deleted" => "is not a valid parameter",
-                       "root" => "is not a valid parameter"
+                       "deleted" => "is not a permitted parameter",
+                       "root" => "is not a permitted parameter"
                      }
                    }
                  }


### PR DESCRIPTION
## Motivation

Rename the "forbidden parameters" error to reduce ambiguity compared to other errors.

